### PR TITLE
chores(depsync): update github.com/cryptellation/version to v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cryptellation/exchanges v1.2.0
 	github.com/cryptellation/health v1.1.1
 	github.com/cryptellation/runtime v1.4.3
-	github.com/cryptellation/version v1.1.0
+	github.com/cryptellation/version v1.4.0
 	github.com/google/uuid v1.6.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/cryptellation/timeseries v1.0.2 h1:Vdrp4AZ7yfBlyANtU7vT9SptBQs8vdjXyj
 github.com/cryptellation/timeseries v1.0.2/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
 github.com/cryptellation/version v1.1.0 h1:guPP4DVPj0Ie1Fnmmiv3VM4xqG7ZMJGjvrS41mHg5Pc=
 github.com/cryptellation/version v1.1.0/go.mod h1:tKR3hxz6uB6AhgA0TKM3Qp6JNAgdQ2PcB0GGcsBWQvg=
+github.com/cryptellation/version v1.4.0 h1:xwtbfl2on1CyoiNYv+yo/uKqO1QMJ2pRmBz6+y0cFMg=
+github.com/cryptellation/version v1.4.0/go.mod h1:tKR3hxz6uB6AhgA0TKM3Qp6JNAgdQ2PcB0GGcsBWQvg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/version** to version **v1.4.0**.

### Changes
- Updated dependency: `github.com/cryptellation/version`
- New version: `v1.4.0`

This update was automatically generated by DepSync.