### PR TITLE
chores(depsync): update github.com/cryptellation/candlesticks to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.8
 require (
 	github.com/adshao/go-binance/v2 v2.8.2
 	github.com/cenkalti/backoff/v5 v5.0.2
-	github.com/cryptellation/candlesticks v1.0.4
+	github.com/cryptellation/candlesticks v1.1.0
 	github.com/cryptellation/exchanges v1.2.0
 	github.com/cryptellation/health v1.1.1
 	github.com/cryptellation/runtime v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cryptellation/candlesticks v1.0.4 h1:OSU4OyIH1+iVsIfEBEjf8vdKOleeLqW0agdl7DV9NYo=
 github.com/cryptellation/candlesticks v1.0.4/go.mod h1:0R+YZ+PBJsV+jindXAzTKfCU7kq+4VpUfKhWv+028GQ=
+github.com/cryptellation/candlesticks v1.1.0 h1:4l46/xInwGJxNFGCvFXDLmgrMkOJBu+R/l1o24JmzFk=
+github.com/cryptellation/candlesticks v1.1.0/go.mod h1:0lyK2y9RNKUOGnQFkeoyMCrkTuccdcnHXx4fndYVA8Y=
 github.com/cryptellation/exchanges v1.1.0 h1:MFHZU8tDP07RhhbwPWXjn/VLI4+lW522IBvA4VB8noo=
 github.com/cryptellation/exchanges v1.1.0/go.mod h1:2iyJgSid50L76UjS5gzV3hnCeq1DS4u/tkaJuq/toKY=
 github.com/cryptellation/exchanges v1.2.0 h1:PYhFhLz2d5ccaPAnzn3+4CCtKeTdzMPSFZVOgp9Aibw=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/candlesticks** to version **v1.1.0**.

### Changes
- Updated dependency: `github.com/cryptellation/candlesticks`
- New version: `v1.1.0`

This update was automatically generated by DepSync.